### PR TITLE
Mccalluc/get build working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+  - "2.7"
+
+#cache: apt
+#addons:
+#  apt:
+#    packages:
+
+install:
+  - pip install -r requirements.txt
+script:
+  - set -e
+  - python setup.py install

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ directory is specified using the (`--output-dir` or `-o` parameter). This
 contains the `tile_info.json` file which contains all of the metadata about the
 tiling:
 
-```
+```json
 {
   "min_importance": 1.0, 
   "min_pos": [
@@ -126,7 +126,7 @@ was 1D, then the id would have one less number.
 Tile boundaries are half-open. This an be illustrated using the following
 code block:
 
-```
+```python
     import json
     import clodius.fpark as cfp
     import clodius.tiles as cti
@@ -144,7 +144,7 @@ code block:
 
 The output will be:
 
-```
+```json
 [
   [
     (0,1),
@@ -201,7 +201,7 @@ that has a value along with its value.
 Used when there are not enough entries to make it worthwhile to return dense
 matrix format. 
 
-```
+```json
 {
   "sparse": [
     {
@@ -225,7 +225,7 @@ area that this tile occupies.
 
 The output of a single tile is just an array of values under the key `dense`.
 
-```
+```json
 {
     "dense": [3.0, 0, 2.0, 1.0]
 }
@@ -233,7 +233,7 @@ The output of a single tile is just an array of values under the key `dense`.
 
 The encoding from bin positions, to positions in the flat array is performed thusly:
 
-```
+```python
 for (bin_pos, bin_val) in tile_entries_iterator.items():
     index = sum([bp * bins_per_dimension ** i for i,bp in enumerate(bin_pos)])
     initial_values[index] = bin_val

--- a/README.md
+++ b/README.md
@@ -2,15 +2,16 @@
 
 ### Requirements
 
+Optionally:
 * Kent-tools (`brew install kent-tools`)
 * Pipe viewer (`brew install pv`)
 
-* Python negspy (`pip install negspy`)
-* Python requests (`pip install requests`)
-
 Install `clodius` by running:
 
-`python setup.py install`
+```
+python setup.py install
+git diff requirements.txt
+```
 
 ## Documentation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-clodius==0.3.0
 Cython==0.24.1
 negspy==0.2.0
 numpy==1.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-slugid
-requests
-negspy
-pandas
-sortedcontainers
-weave
+clodius==0.3.0
+Cython==0.24.1
+negspy==0.2.0
+numpy==1.12.0
+requests==2.12.4


### PR DESCRIPTION
@pkerpedjiev : How does this look to you? On the first build, Travis hit the same Cython.Build error that we've seen elsewhere. Then cleaned up the dependencies, and the build works now, though I'm not sure that will imply anything downstream.

The first run had `clodius==0.3.0` as a dependency: The result of a `pip freeze`, though it still confuses me. The second didn't, and I think it took longer as the result.

- Should the generated C code be checked in? Anyone who regenerates will cause a lot of diffs in comments.
- If this seems ok, can be bump the version number and push to pypi?