### PR TITLE
Docker exists by default on travis now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,8 @@
-# Docker on Travis requires sudo.
 sudo: required
 language: python
 python:
       - "3.6"
       - "2.7"
-
-install:
-  # Docker 1.13 adds "--cache-from" which really speeds up our Travis builds.
-  # Travis is currently several versions behind: When/if they catch up,
-  # this can all go away, and we can stop sudoing docker.
-  - sudo apt-get install libapparmor1
-  - DEB=docker-engine_1.13.0-0~ubuntu-precise_amd64.deb
-  - wget https://apt.dockerproject.org/repo/pool/main/d/docker-engine/$DEB
-  - sudo dpkg -i $DEB
-  - sudo docker --version
 
 script:
   - set -e


### PR DESCRIPTION
- So this at least allows travis to run properly without the error about docker versions clashing.
- Tests are still failing though which is concerning