### PR TITLE
Added int() cast to deal with Python3 int->float promotion on division

### DIFF
--- a/clodius/multivec.py
+++ b/clodius/multivec.py
@@ -254,7 +254,7 @@ def create_multivec_multires(array_data, chromsizes,
                       "resolution:", curr_resolution, 
                       "new_data length", len(new_data))
                 '''
-                f['resolutions'][str(curr_resolution)]['values'][chrom][start/2:start/2+chunk_size/2] = new_data
+                f['resolutions'][str(curr_resolution)]['values'][chrom][int(start/2):int(start/2+chunk_size/2)] = new_data
                 start += int(min(standard_chunk_size, len(chrom_data) - start))
 
         prev_resolution = curr_resolution


### PR DESCRIPTION
Conversion of `hg19` and `hg38` test epilogos BED files resulted in `TypeError` exceptions being thrown at line 257 of `clodius/multivec.py`, where array slice indices were not integers. 

For example:

```
$ clodius convert bedfile_to_multivec /tmp/hg19.all.KL.bed.gz \
--assembly hg19 \
--starting-resolution 200 \
--row-infos-filename /home/ubuntu/epilogos_hg19_observed_states.txt \
--num-rows 15 \
--format epilogos
temporary dir: /tmp/tmpukx87bau
dumping batch: chr1 100000
dumping batch: chr1 200000
dumping batch: chr1 300000
dumping batch: chr1 400000
dumping batch: chr1 500000
…
dumping batch: chrX 600000
dumping batch: chrX 700000
output_file: /tmp/hg19.all.KL.bed.multires.mv5
creating new dataset
array_data.shape (1246253, 15)
copy start: 0 100000
copy start: 100000 100000
…
creating new dataset
array_data.shape (21, 15)
copy start: 0 21
start: 0
Traceback (most recent call last):
  File "/home/ubuntu/anaconda3/bin/clodius", line 11, in <module>
    load_entry_point('clodius', 'console_scripts', 'clodius')()
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/ubuntu/github/hms-dbmi/clodius/clodius/cli/convert.py", line 227, in bedfile_to_multivec
    format, row_infos_filename, tile_size)
  File "/home/ubuntu/github/hms-dbmi/clodius/clodius/cli/convert.py", line 124, in _bedgraph_to_multivec
    row_infos=row_infos)
  File "/home/ubuntu/github/hms-dbmi/clodius/clodius/multivec.py", line 257, in create_multivec_multires
    f['resolutions'][str(curr_resolution)]['values'][chrom][start/2:start/2+chunk_size/2] = new_data
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/h5py/_hl/dataset.py", line 609, in __setitem__
    selection = sel.select(self.shape, args, dsid=self.id)
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/h5py/_hl/selections.py", line 94, in select
    sel[args]
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/h5py/_hl/selections.py", line 261, in __getitem__
    start, count, step, scalar = _handle_simple(self.shape,args)
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/h5py/_hl/selections.py", line 447, in _handle_simple
    x,y,z = _translate_slice(arg, length)
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/h5py/_hl/selections.py", line 480, in _translate_slice
    start, stop, step = exp.indices(length)
TypeError: slice indices must be integers or None or have an __index__ method
```

The conda and virtualenv environments I am using for testing use a Python 3 environment. 

In a Python 2 environment, dividing two `int` values returns an `int`:

```
$ /usr/bin/python
Python 2.7.10 (default, Oct  6 2017, 22:29:07) 
[GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> type(0)
<type 'int'>
>>> type(2)
<type 'int'>
>>> type(0/2)
<type 'int'>
```

In Python 3, however, the result of division is promoted to a `float`:

```
$ python
Python 3.6.4 |Anaconda custom (64-bit)| (default, Jan 16 2018, 18:10:19) 
[GCC 7.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> type(0)
<class 'int'>
>>> type(2)
<type 'int'>
>>> type(0/2)
<class 'float'>
```

Casting the indices values to explicit integers helped resolve this exception. I think that use of `int()` should also preserve compatibility with Python 2 environments.